### PR TITLE
refactor: streamline pixel writes and blitting

### DIFF
--- a/packages/st7789-driver/src/st7789.ts
+++ b/packages/st7789-driver/src/st7789.ts
@@ -106,9 +106,9 @@ export class ST7789 {
       out[j++] = v & 0xff;
     }
     const MAX_SPI_BYTES = Number(process.env.SPI_BUFSIZ ?? 4096);
+    this.dc.high();
     for (let off = 0; off < out.length; off += MAX_SPI_BYTES) {
       const chunk = out.subarray(off, Math.min(off + MAX_SPI_BYTES, out.length));
-      this.dc.high();
       this.spi.write(chunk);
     }
   }

--- a/packages/st7789-gfx2d/src/gfx2d.ts
+++ b/packages/st7789-gfx2d/src/gfx2d.ts
@@ -216,17 +216,34 @@ export class Gfx2D {
     const key = opts?.key;
     const tint = opts?.tint;
     const W=this.W,H=this.H;
-    for (let y=0; y<sh; y++){
-      const yy = dy + y; if (yy<0||yy>=H) continue;
-      const syy = sy + y;
-      for (let x=0; x<sw; x++){
-        const xx = dx + x; if (xx<0||xx>=W) continue;
-        const sCol = src[syy*sw + (sx + x)];
-        if (key !== undefined && sCol === key) continue;
-        const srcTinted = tint ? this.modulate565(sCol, tint) : sCol;
-        const off = yy*W + xx;
-        if (alpha===255) this.buf[off] = srcTinted;
-        else this.buf[off] = this.blend565(srcTinted, this.buf[off], alpha);
+    if (alpha === 255){
+      for (let y=0; y<sh; y++){
+        const yy = dy + y; if (yy<0||yy>=H) continue;
+        const syy = sy + y;
+        const srcRow = syy*sw + sx;
+        const dstRow = yy*W + dx;
+        for (let x=0; x<sw; x++){
+          const xx = dx + x; if (xx<0||xx>=W) continue;
+          const sCol = src[srcRow + x];
+          if (key !== undefined && sCol === key) continue;
+          const srcTinted = tint ? this.modulate565(sCol, tint) : sCol;
+          this.buf[dstRow + x] = srcTinted;
+        }
+      }
+    } else {
+      for (let y=0; y<sh; y++){
+        const yy = dy + y; if (yy<0||yy>=H) continue;
+        const syy = sy + y;
+        const srcRow = syy*sw + sx;
+        const dstRow = yy*W + dx;
+        for (let x=0; x<sw; x++){
+          const xx = dx + x; if (xx<0||xx>=W) continue;
+          const sCol = src[srcRow + x];
+          if (key !== undefined && sCol === key) continue;
+          const srcTinted = tint ? this.modulate565(sCol, tint) : sCol;
+          const off = dstRow + x;
+          this.buf[off] = this.blend565(srcTinted, this.buf[off], alpha);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- avoid redundant data/command pin toggling when sending pixel blocks
- precompute row offsets and skip alpha branch for opaque blits

## Testing
- `bun run build` (packages/st7789-driver)
- `bun run build` (packages/st7789-gfx2d) *(fails: Cannot find module 'st7789-driver')*

------
https://chatgpt.com/codex/tasks/task_e_6898ee8cd5dc8320a34134f2f7c62e9e