### PR TITLE
feat: add emotion system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,20 @@
         "typescript": "^5.0.0",
       },
     },
+    "packages/emotion-system": {
+      "name": "emotion-system",
+      "dependencies": {
+        "st7789-gfx2d": "workspace:*",
+        "state-machine": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^24.2.0",
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0",
+      },
+    },
     "packages/st7789-driver": {
       "name": "st7789-driver",
       "dependencies": {
@@ -74,6 +88,8 @@
     "color": ["color@workspace:packages/color"],
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "emotion-system": ["emotion-system@workspace:packages/emotion-system"],
 
     "st7789-driver": ["st7789-driver@workspace:packages/st7789-driver"],
 

--- a/packages/emotion-system/package.json
+++ b/packages/emotion-system/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "emotion-system",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "dev": "bun run --watch src/index.ts",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/node": "^24.2.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "state-machine": "workspace:*",
+    "st7789-gfx2d": "workspace:*"
+  }
+}

--- a/packages/emotion-system/src/emotion-system.test.ts
+++ b/packages/emotion-system/src/emotion-system.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "bun:test";
+import { EmotionSystem, type Frame, type Emotion } from "./index.ts";
+
+class StubGfx {
+  buf = new Uint16Array(1);
+  setPixel(x: number, y: number, color: number) {
+    this.buf[0] = color;
+  }
+}
+
+describe("EmotionSystem", () => {
+  it("plays frames and updates current emotion", async () => {
+    const gfx = new StubGfx();
+    const frame: Frame = {
+      duration: 0,
+      draw: (g) => g.setPixel(0, 0, 0xffff),
+    };
+    const emotion: Emotion = { onMain: { frames: [frame] } };
+
+    const system = new EmotionSystem(gfx as any);
+    system.addEmotion("test", emotion);
+    await system.play("test");
+
+    expect(system.currentEmotion).toBe("test");
+    expect(gfx.buf[0]).toBe(0xffff);
+  });
+
+  it("can transition back to idle", async () => {
+    const gfx = new StubGfx();
+    const system = new EmotionSystem(gfx as any);
+    system.addEmotion("test", { onMain: { frames: [] } });
+    await system.play("test");
+    await system.play("idle");
+    expect(system.currentEmotion).toBe("idle");
+  });
+});

--- a/packages/emotion-system/src/index.ts
+++ b/packages/emotion-system/src/index.ts
@@ -1,0 +1,102 @@
+import {
+  createStateMachine,
+  type StateConfig,
+  type StateMachine,
+} from "../../state-machine/src/index.ts";
+import type { Gfx2D } from "../../st7789-gfx2d/src/gfx2d.ts";
+
+export interface Frame {
+  duration: number;
+  draw: (gfx: Gfx2D) => void;
+}
+
+export interface Animation {
+  frames: Frame[];
+}
+
+export interface Emotion {
+  onEnter?: Animation;
+  onMain: Animation;
+  onLeave?: Animation;
+}
+
+export type EmotionKey = string | "idle";
+
+interface Ctx {
+  system: EmotionSystem;
+}
+
+/**
+ * EmotionSystem manages named emotions and plays their animations using a state machine.
+ */
+export class EmotionSystem {
+  private config: StateConfig<EmotionKey, EmotionKey, Ctx, EmotionKey> = {};
+  private sm: StateMachine<EmotionKey, EmotionKey, Ctx, EmotionKey>;
+  private emotions = new Map<EmotionKey, Emotion>();
+  private current: EmotionKey;
+  private currentPromise: Promise<void> = Promise.resolve();
+
+  constructor(private gfx: Gfx2D, initial: EmotionKey = "idle") {
+    this.current = initial;
+    this.config[initial] = {};
+    this.sm = createStateMachine(initial, this.config, { system: this });
+    // ensure initial state exists even if no emotion defined
+    this.emotions.set(initial, { onMain: { frames: [] } });
+  }
+
+  /**
+     * Register a new emotion.
+     */
+  addEmotion(key: EmotionKey, emotion: Emotion) {
+    this.emotions.set(key, emotion);
+    if (!this.config[key]) this.config[key] = {};
+
+    // create transitions from every state to the new one and vice versa
+    for (const state of Object.keys(this.config) as EmotionKey[]) {
+      this.config[state][key] = {
+        target: key,
+        action: (ctx) => {
+          ctx.system.current = key;
+          ctx.system.currentPromise = ctx.system.playEmotion(key);
+        },
+      };
+      this.config[key][state] = {
+        target: state,
+        action: (ctx) => {
+          ctx.system.current = state;
+          ctx.system.currentPromise = ctx.system.playEmotion(state);
+        },
+      };
+    }
+  }
+
+  /**
+     * Play an emotion by name. Returns a promise that resolves when the emotion's
+     * animations complete.
+     */
+  play(key: EmotionKey): Promise<void> {
+    this.sm.send(key, key);
+    return this.currentPromise;
+  }
+
+  get currentEmotion(): EmotionKey {
+    return this.current;
+  }
+
+  private async playEmotion(key: EmotionKey): Promise<void> {
+    const emo = this.emotions.get(key);
+    if (!emo) return;
+    if (emo.onEnter) await this.playAnimation(emo.onEnter);
+    await this.playAnimation(emo.onMain);
+    if (emo.onLeave) await this.playAnimation(emo.onLeave);
+  }
+
+  private async playAnimation(animation: Animation): Promise<void> {
+    for (const frame of animation.frames) {
+      frame.draw(this.gfx);
+      if (frame.duration > 0) {
+        await new Promise((resolve) => setTimeout(resolve, frame.duration));
+      }
+    }
+  }
+}

--- a/packages/emotion-system/tsconfig.json
+++ b/packages/emotion-system/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "allowJs": true,
+
+    "outDir": "dist/",
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add emotion-system package leveraging state-machine to orchestrate animations
- support registering emotions and asynchronous frame playback
- provide unit tests for emotion transitions

## Testing
- `bun test packages/emotion-system`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_689a0bcb030c832090be82f3180e7b4d